### PR TITLE
IMX273 4-lane binning: HMAX=218 truncates the binned line to half width (use 238)

### DIFF
--- a/vc_mipi_modules.c
+++ b/vc_mipi_modules.c
@@ -373,7 +373,7 @@ static void vc_init_ctrl_imx273(struct vc_ctrl *ctrl, struct vc_desc* desc)
         MODE( 6, 2, FORMAT_RAW08, 1,     336,   15,  0xfffff,   586,  255,   15,    519230)
         MODE( 7, 2, FORMAT_RAW10, 1,     420,   15,  0xfffff,   586, 1023,   60,    519230)
         MODE( 8, 2, FORMAT_RAW12, 1,     480,   15,  0xfffff,   586, 4095,  240,    519230)
-        MODE( 9, 4, FORMAT_RAW08, 1,     218,   15,  0xfffff,   586,  255,   15,    519230)
+        MODE( 9, 4, FORMAT_RAW08, 1,     238,   15,  0xfffff,   586,  255,   15,    519230)
         MODE(10, 4, FORMAT_RAW10, 1,     250,   15,  0xfffff,   586, 1032,   60,    519230)
         MODE(11, 4, FORMAT_RAW12, 1,     396,   15,  0xfffff,   586, 4095,  240,    519230)
 


### PR DESCRIPTION
## Summary

In the IMX273 **4-lane RAW8 binning** mode (FPGA module mode `0x12` / mode 18), the mode table programs
the sensor HMAX too short (**218**), which truncates the binned readout to roughly half the line — the
right half of the frame is empty (hard black) while `o_width` still reads 720. Restoring the binned-mode
HMAX to **238** (the module controller's mode-18 default, which the older bcm2835 0.2.7 driver leaves in
place) clocks out all 720 binned columns and fixes it.

This is a one-line change to the IMX273 mode table in `vc_mipi_modules.c` (`hmax.def` 218 → 238 for the
4-lane RAW8 binning mode).

## Environment

- Sensor: VC MIPI **IMX273** (mono), Raspberry Pi **CM4**, 4-lane, 8-bit (`Y8_1X8`), 2×2 binning
  (FPGA module mode `0x12`).
- Driver: `vc_mipi_core` on the `raspberrypi/develop` branch, Linux 6.12.
- Reference: the older bcm2835-specific driver (0.2.7) on Linux 5.15 produces a correct full-width
  binned image on the same hardware.

## Symptom

In binned mode the captured frame has real content only in the left ~360 columns; the right half is
hard black (empty data), while `o_width` reads 720 and the bridge declares 720×540. Non-binned mode is
unaffected.

## Root cause (confirmed by on-device A/B)

The mode table writes HMAX (sensor `0x0214`/`0x0215`) = **218** for IMX273 4-lane binning; the
known-good configuration is **238** (the module's mode-18 default — the bcm2835 driver never overrides
HMAX). 218 is too short a line period to clock out all 720 binned columns, so the readout truncates
~halfway.

Scene-independent A/B — value re-latched directly on the sensor (stop → write HMAX → start), so only
HMAX changes. Metric is the right-half pixel standard deviation (0 = flat/no data, > 0 = real signal):

| HMAX | right half | result |
|---|---|---|
| **218** (current) | mean ≈ 1, **std 0** — no data | half frame |
| **238** | mean ≈ 135, **std ≈ 23** — real, structured data matching the left half | full frame |

Toggles reproducibly. For comparison, `o_width` 720→1440 had **no** effect, and the module-controller
(`0x10`) mode/width registers showed no relevant deviation (mode correctly `0x12`) — so it is purely the
HMAX line period.

## Fix

Set the IMX273 4-lane RAW8 binning mode `hmax.def` to **238** in `vc_mipi_modules.c`. Updating the value
via the mode table (rather than dropping the write) matters: HMAX also feeds the Sony SHS/exposure
formula, so a bare register change without updating the SHS basis over-exposes the frame. Using the
mode-table value keeps the register write and the exposure math consistent.

```diff
-        MODE( 9, 4, FORMAT_RAW08, 1,     218,   15,  0xfffff,   586,  255,   15,    519230)
+        MODE( 9, 4, FORMAT_RAW08, 1,     238,   15,  0xfffff,   586,  255,   15,    519230)
```

## Verification

On a real device (IMX273 mono, Raspberry Pi CM4, Linux 6.12):

- **Full width restored** — the previously empty right half now carries real, correctly-exposed image
  data (right-half pixel std 0 → ~23), matching the left half.
- **Frame rate maintained** — `v4l2-ctl --stream-mmap` on the bridge node measured **532 fps** for the
  binned 720×540 stream, comfortably above the 500 fps target (`HMAX 238 → clk_pixel/(238·VMAX)`).
- **Exposure correct** — because SHS is computed from the same 238, the frame is properly exposed (not
  the over-exposed look of a bare register poke).

## Bonus

This also resolves a separate symptom: a gain-dependent black-notch (the binned image going black over
certain `analogue_gain` ranges). It was a side-effect of the truncated readout and disappears once
HMAX=238 restores the full line — confirmed by a monotonic gain→brightness sweep across the previously
affected codes.
